### PR TITLE
Improve compilation on Linux; fix some bugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,19 @@ AR         = ar
 COMPILE_ET = compile_et
 RANLIB     = ranlib
 
+AFSLIBS = /usr/local/lib/afs
+ifeq ($(wildcard $(AFSLIBS)/*),)
+AFSLIBS = /usr/lib/afs
+ifeq ($(wildcard $(AFSLIBS)/*),)
+$(error AFS static libraries not found.)
+endif
+endif
+
 # On Linux:
 ifeq ($(shell uname),Linux)
 R=-Wl,-rpath,
 XLIBS=-lresolv
+XCFLAGS=-W -Wall -Wno-parentheses -Wno-unused-parameter -Wno-implicit-function-declaration
 endif
 
 # On Solaris:
@@ -43,13 +52,13 @@ endif
 
 DEBUG      = -g
 INCLUDES   = -I/usr/local/include
-CFLAGS     = $(DEBUG) $(INCLUDES) -DNATIVE_INT64='long long'
-LDFLAGS    = -L. -L/usr/local/lib $(R)/usr/local/lib -L/usr/local/lib/afs $(XLDFLAGS)
+CFLAGS     = $(DEBUG) $(XCFLAGS) $(INCLUDES) -DNATIVE_INT64='long long'
+LDFLAGS    = -L. -L/usr/local/lib $(R)/usr/local/lib -L$(AFSLIBS) $(XLDFLAGS)
 
 LIBS                 = -ldumpscan -lxfiles \
                        -lauth -laudit -lvolser -lvldb -lubik -lrxkad \
-                       /usr/local/lib/afs/libsys.a -lrx -llwp \
-                       -lcom_err /usr/local/lib/afs/util.a $(XLIBS)
+                       $(AFSLIBS)/libsys.a -lrx -llwp \
+                       -lcom_err -lafscom_err $(AFSLIBS)/util.a $(XLIBS)
 OBJS_afsdump_scan    = afsdump_scan.o repair.o
 OBJS_afsdump_xsed    = afsdump_xsed.o repair.o
 OBJS_libxfiles.a     = xfiles.o xfopen.o xf_errs.o xf_printf.o int64.o \

--- a/afsdump_extract.c
+++ b/afsdump_extract.c
@@ -322,11 +322,11 @@ static afs_uint32 directory_cb(afs_vnode *v, XFILE *X, void *refcon)
   if (verbose) {
     if (use_vnum) 
       printf("d%s %3d %-11d %11d %s #%d:%d\n",
-             modestr(v->mode), v->nlinks, v->owner, v->size,
+             modestr(v->mode), v->nlinks, v->owner, lo64(v->size),
              datestr(v->server_date), v->vnode, v->vuniq);
     else
       printf("d%s %3d %-11d %11d %s %s\n",
-             modestr(v->mode), v->nlinks, v->owner, v->size,
+             modestr(v->mode), v->nlinks, v->owner, lo64(v->size),
              datestr(v->server_date), vnodepath);
   }
   else if (!quiet && !use_vnum)
@@ -383,7 +383,7 @@ static afs_uint32 file_cb(afs_vnode *v, XFILE *X, void *refcon)
   /* Print it out */
   if (verbose) {
     printf("-%s %3d %-11d %11d %s %s\n",
-           modestr(v->mode), v->nlinks, v->owner, v->size,
+           modestr(v->mode), v->nlinks, v->owner, lo64(v->size),
            datestr(v->server_date), vnodepath);
   } else if (!quiet) {
     printf("%s\n", vnodepath);
@@ -454,7 +454,7 @@ static afs_uint32 symlink_cb(afs_vnode *v, XFILE *X, void *refcon)
   /* Print it out */
   if (verbose)
     printf("l%s %3d %-11d %11d %s %s -> %s\n",
-           modestr(v->mode), v->nlinks, v->owner, v->size,
+           modestr(v->mode), v->nlinks, v->owner, lo64(v->size),
            datestr(v->server_date), vnodepath, linktarget);
   else if (!quiet)
     printf("%s\n", vnodepath);

--- a/repair.c
+++ b/repair.c
@@ -220,7 +220,8 @@ afs_uint32 repair_vnode_cb(afs_vnode *v, XFILE *X, void *refcon)
   mk64(zero64, 0, 0);
 
   if ((v->vnode & 1) && !field_mask) {
-    if (RV) fprintf(stderr, ">>> VNODE %d is directory but has no fields?\n");
+    if (RV) fprintf(stderr, ">>> VNODE %d is directory but has no fields?\n",
+                    v->vnode);
     v->type = vDirectory;
     v->field_mask |= F_VNODE_TYPE;
     field_mask = F_VNODE_TYPE; /* Messy! */
@@ -285,7 +286,8 @@ afs_uint32 repair_vnode_cb(afs_vnode *v, XFILE *X, void *refcon)
     v->field_mask |= F_VNODE_SDATE;
   }
   if (field_mask && !(field_mask & F_VNODE_SIZE)) {
-    if (RV) fprintf(stderr, ">>> VNODE %d has no data size (using 0)\n");
+    if (RV) fprintf(stderr, ">>> VNODE %d has no data size (using 0)\n",
+                    v->vnode);
     mk64(v->size, 0, 0);
     v->field_mask |= F_VNODE_SIZE;
   }
@@ -298,7 +300,8 @@ afs_uint32 repair_vnode_cb(afs_vnode *v, XFILE *X, void *refcon)
   if (field_mask && v->type == vDirectory && !(field_mask & F_VNODE_ACL)) {
     struct acl_accessList *acl = (struct acl_accessList *)v->acl;
     if (RV) {
-      fprintf(stderr, ">>> VNODE %d is directory but has no ACL\n");
+      fprintf(stderr, ">>> VNODE %d is directory but has no ACL\n",
+              v->vnode);
       fprintf(stderr, ">>> Will generate default ACL\n");
     }
     memset(v->acl, 0, SIZEOF_LARGEDISKVNODE - SIZEOF_SMALLDISKVNODE);
@@ -330,7 +333,8 @@ afs_uint32 repair_vnode_cb(afs_vnode *v, XFILE *X, void *refcon)
     u_int64 tmp64;
 
     if (RV) {
-      fprintf(stderr, ">>> VNODE %d is directory but has no contents\n");
+      fprintf(stderr, ">>> VNODE %d is directory but has no contents\n",
+              v->vnode);
       fprintf(stderr, ">>> Will generate deafult directory entries\n");
     }
     memset(&page, 0, sizeof(page));


### PR DESCRIPTION
AFS libs are located automatically, and extended warnings are enabled for GCC
except where they obviously conflict with code style.  A couple bugs found by
warnings are fixed.
